### PR TITLE
Added an additional way to enter a password & "-o" option now writes the output to a file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ node_modules/
 
 # mkdocs
 site/
+
+# PyCharm files.
+.idea/

--- a/query_phenomizer/cli.py
+++ b/query_phenomizer/cli.py
@@ -16,6 +16,8 @@ import json
 
 from query_phenomizer import query, validate_term
 
+from getpass import getpass
+
 from .log import (configure_stream, LEVELS)
 
 logger = logging.getLogger(__name__)
@@ -69,10 +71,13 @@ def cli(ctx, hpo_term, check_terms, output, p_value_limit, verbose, username,
         logger.info("Please specify at least one hpo term with '-t/--hpo_term'.")
         ctx.abort()
 
-    if not (username and password):
+    if not username:
         logger.info("Please specify username with -u and password with -p.")
         logger.info("Contact sebastian.koehler@charite.de.")
         ctx.abort()
+
+    if not password:
+        password = getpass("password:")
     
     hpo_list = []
     for term in hpo_term:

--- a/query_phenomizer/cli.py
+++ b/query_phenomizer/cli.py
@@ -104,7 +104,8 @@ def cli(ctx, hpo_term, check_terms, output, p_value_limit, verbose, username,
     else:
         try:
             if output:
-                output.write("p-value\tdisease-id\tdisease-name\tgene-symbols")
+                header = "p-value\tdisease-id\tdisease-name\tgene-symbols" + linesep  # The file header.
+                output.write(header.encode())  # "a bytes-like object is required"
             for result in query(username, password, *hpo_list):
                 if to_json:
                     click.echo(json.dumps(result))

--- a/query_phenomizer/cli.py
+++ b/query_phenomizer/cli.py
@@ -63,7 +63,9 @@ def test_args(*args):
 @click.pass_context
 def cli(ctx, hpo_term, check_terms, output, p_value_limit, verbose, username, 
         password, to_json):
-    "Give hpo terms either on the form 'HP:0001623', or '0001623'"    
+    """Give hpo terms either on the form 'HP:0001623', or '0001623'.
+
+    If -p is not used, a password prompt will appear instead."""
     loglevel = LEVELS.get(min(verbose, 3))
     configure_stream(level=loglevel)
     

--- a/query_phenomizer/cli.py
+++ b/query_phenomizer/cli.py
@@ -110,7 +110,7 @@ def cli(ctx, hpo_term, check_terms, output, p_value_limit, verbose, username,
                 if to_json:
                     click.echo(json.dumps(result))
                 else:
-                    print_string = '{0}\t{1}:{2}\t"{3}"\t{4}'.format(
+                    print_string = '{0}\t{1}:{2}\t{3}\t{4}'.format(
                         result['p_value'],
                         result['disease_source'],
                         result['disease_nr'],

--- a/query_phenomizer/cli.py
+++ b/query_phenomizer/cli.py
@@ -110,7 +110,7 @@ def cli(ctx, hpo_term, check_terms, output, p_value_limit, verbose, username,
                 if to_json:
                     click.echo(json.dumps(result))
                 else:
-                    print_string = '{0}\t{1}:{2}\t{3}\t{4}'.format(
+                    print_string = "{0}\t{1}:{2}\t{3}\t{4}".format(
                         result['p_value'],
                         result['disease_source'],
                         result['disease_nr'],

--- a/query_phenomizer/cli.py
+++ b/query_phenomizer/cli.py
@@ -75,7 +75,7 @@ def cli(ctx, hpo_term, check_terms, output, p_value_limit, verbose, username,
         ctx.abort()
 
     if not username:
-        logger.info("Please specify username with -u and password with -p.")
+        logger.info("Please specify username with -u (and password with -p).")
         logger.info("Contact sebastian.koehler@charite.de.")
         ctx.abort()
 

--- a/query_phenomizer/cli.py
+++ b/query_phenomizer/cli.py
@@ -128,3 +128,7 @@ def cli(ctx, hpo_term, check_terms, output, p_value_limit, verbose, username,
         except RuntimeError as e:
             click.echo(e)
             ctx.abort()
+        finally:
+            if output:
+                output.flush()
+                output.close()


### PR DESCRIPTION
When running the app I noticed that the output was not written to a file while using "-o", so I took the liberty to make some adjustments (hope you don't mind). These include:
* Added PyCharm folder to `.gitignore`.
* Implemented usage of `getpass()` so that a password prompt appears when not using `-p` (this way a password will not be stored in the terminal history).
* Implemented output writing to a file using the `-o` option (not sure how click handles file flushing/closing, though added a finally clause to do this just to be sure). The output file has a file header as well.